### PR TITLE
updates after technical revew

### DIFF
--- a/notebooks/MIRI/JWpipeNB-MIRI-imaging.ipynb
+++ b/notebooks/MIRI/JWpipeNB-MIRI-imaging.ipynb
@@ -26,8 +26,7 @@
    "id": "6a74b566-3d8c-4985-a4f3-d654a6d39371",
    "metadata": {},
    "source": [
-    "# **Purpose**:\n",
-    "\n",
+    "**Purpose**:<br>\n",
     "This notebook provides a framework for processing generic Mid-Infrared Instrument \n",
     "(MIRI) Imaging data through all\n",
     "three James Webb Space Telescope (JWST) pipeline stages.  Data is assumed\n",
@@ -36,44 +35,40 @@
     "[Configuration](#1.-Configuration) section unless modifying the standard\n",
     "pipeline processing options.\n",
     "\n",
-    "**Data**:\n",
+    "**Data**:<br>\n",
     "This example is set up to use an example dataset is from\n",
     "[Program ID](https://www.stsci.edu/jwst/science-execution/program-information)\n",
     "1040 (PI: O. Detre, Co-I: A. Noriega-Crespo) which is an external flat commissioning program.\n",
+    "The MIRI imaging dataset uses a 5-step dither pattern. Example input data to use will be\n",
+    "downloaded automatically unless disabled (i.e., to use local files instead).\n",
     "\n",
-    "The MIRI imaging dataset uses a 5-step dither pattern.\n",
-    "\n",
-    "Example input data to use will be downloaded automatically unless\n",
-    "disabled (i.e., to use local files instead).\n",
-    "\n",
-    "**JWST pipeline version and CRDS context** This notebook was written for the\n",
-    "calibration pipeline version given above. It sets the CRDS context\n",
-    "to use the most recent version available in the JWST Calibration\n",
-    "Reference Data System (CRDS). If you use different pipeline versions or\n",
-    "CRDS context, please read the relevant release notes\n",
+    "**JWST pipeline version and CRDS context**:<br>\n",
+    "This notebook was written for the calibration pipeline version given above.\n",
+    "It sets the CRDS context to use the most recent that applies to the version\n",
+    "of the JWST Calibration Pipeline. The information about this context is available \n",
+    "in the JWST Calibration Reference Data System (CRDS). If you use different pipeline\n",
+    "versions or CRDS context, please read the relevant release notes\n",
     "([here for pipeline](https://github.com/spacetelescope/jwst),\n",
     "[here for CRDS](https://jwst-crds.stsci.edu/)) for possibly relevant\n",
     "changes.<BR>\n",
     "\n",
-    "**Updates**:\n",
+    "**Updates**:<br>\n",
     "This notebook is regularly updated as improvements are made to the\n",
     "pipeline. Find the most up to date version of this notebook at:\n",
     "https://github.com/spacetelescope/jwst-pipeline-notebooks/\n",
     "\n",
     "**Recent Changes**:<br>\n",
-    "September 25, 2024: original notebook released<br>\n",
-    "\n",
-    "\n",
+    "September 25, 2024: original notebook released<br><br>\n",
     "\n",
     "## Table of Contents\n",
-    "1. [Configuration](#1.-Configuration) \n",
+    "1. [Configuration](#1.-Configuration)\n",
     "2. [Package Imports](#2.-Package-Imports)\n",
     "3. [Demo Mode Setup (ignore if not using demo data)](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
     "4. [Directory Setup](#4.-Directory-Setup)\n",
     "3. [Detector 1 Pipelineg](#5.-Detector1-Pipeline)\n",
     "4. [Image2 Pipeline](#6.-Image2-Pipeline)\n",
     "5. [Image3 Pipeline](#7.-Image3-Pipeline)\n",
-    "6. [Visualize the data](#8.-Visualize-the-data)\n"
+    "6. [Visualize the data](#8.-Visualize-the-drizzle-combined-image)"
    ]
   },
   {
@@ -91,7 +86,7 @@
    "id": "026a649d-a0d2-4e3f-ab6d-cf8c26e6ce1d",
    "metadata": {},
    "source": [
-    "#### Install dependencies and parameters"
+    "### Install dependencies and parameters"
    ]
   },
   {
@@ -102,7 +97,7 @@
     "To make sure that the pipeline version is compatabile with the steps\n",
     "discussed below and the required dependencies and packages are installed,\n",
     "you can create a fresh conda environment and install the provided\n",
-    "`requirements.txt` file:\n",
+    "`requirements.txt` file before starting this notebook: <br>\n",
     "```\n",
     "conda create -n miri_imaging_pipeline python=3.11\n",
     "conda activate miri_imaging_pipeline\n",
@@ -120,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "06ea414c",
    "metadata": {},
    "outputs": [],
@@ -140,10 +135,11 @@
     "\n",
     "Set <code>demo_mode = True </code> to run in demonstration mode. In this\n",
     "mode this notebook will download example data from the Barbara A.\n",
-    "Mikulski Archive for Space Telescopes (MAST) and process it through the\n",
-    "pipeline. This will all happen in a local directory unless modified\n",
-    "in [Section 3](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data))\n",
-    "below.\n",
+    "Mikulski Archive for Space Telescopes\n",
+    "([MAST](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html))\n",
+    "and process it through the pipeline. This will all happen in a local\n",
+    "directory unless modified in\n",
+    "[Section 3](#3.-Demo-Mode-Setup-(ignore-if-not-using-demo-data)) below.<br>\n",
     "\n",
     "Set <code>demo_mode = False</code> if you want to process your own data\n",
     "that has already been downloaded and provide the location of the data.<br>"
@@ -151,13 +147,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "323f87d0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running in demonstration mode using online example data!\n"
+     ]
+    }
+   ],
    "source": [
-    "# Set parameters for demo_mode, channel, band, data mode directories, and \n",
-    "# processing steps.\n",
+    "# Set parameters for demo_mode and processing steps.\n",
     "\n",
     "# -----------------------------Demo Mode---------------------------------\n",
     "demo_mode = True\n",
@@ -198,7 +201,7 @@
     "Before importing <code>CRDS</code> and <code>JWST</code> modules, we need\n",
     "to configure our environment. This includes defining a CRDS cache\n",
     "directory in which to keep the reference files that will be used by the\n",
-    "calibration pipeline.\n",
+    "calibration pipeline.<br>\n",
     "\n",
     "If the root directory for the local CRDS cache directory has not been set\n",
     "already, it will be set to create one in the home directory."
@@ -206,16 +209,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "baf7070d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: CRDS_CONTEXT=jwst_1295.pmap\n",
+      "CRDS local filepath: /Users/rdiaz/crds_cache\n",
+      "CRDS file server: https://jwst-crds.stsci.edu\n",
+      "CRDS CONTEXT: jwst_1295.pmap\n"
+     ]
+    }
+   ],
    "source": [
     "# ------------------------Set CRDS context and paths----------------------\n",
+    "# Set CRDS context. If overriding to use a specific version of reference\n",
+    "# files; leave commented out to use the default context. This is, the latest\n",
+    "# reference files associated with the version of the calibration pipeline.\n",
     "\n",
-    "# Set CRDS context (if overriding to use a specific version of reference\n",
-    "# files; leave commented out to use latest reference files by default)\n",
-    "#%env CRDS_CONTEXT  jwst_1254.pmap\n",
+    "# In the near future, STScI will move to a model where each version of the\n",
+    "# calibration pipeline is associated with a specific CRDS context file. Here,\n",
+    "# we explicitly set the context for the version of the jwst Calibration pipeline\n",
+    "# specificed in this notebook's requirement file.\n",
+    "%env CRDS_CONTEXT jwst_1295.pmap\n",
     "\n",
     "# Check whether the local CRDS cache directory has been set.\n",
     "# If not, set it to the user home directory\n",
@@ -227,7 +246,8 @@
     "\n",
     "# Echo CRDS path in use\n",
     "print(f\"CRDS local filepath: {os.environ['CRDS_PATH']}\")\n",
-    "print(f\"CRDS file server: {os.environ['CRDS_SERVER_URL']}\")"
+    "print(f\"CRDS file server: {os.environ['CRDS_SERVER_URL']}\")\n",
+    "print(f\"CRDS CONTEXT: {os.environ['CRDS_CONTEXT']}\")"
    ]
   },
   {
@@ -240,10 +260,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "4415f6d9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width:95% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Use the entire available screen width for this notebook\n",
     "from IPython.display import display, HTML\n",
@@ -252,10 +285,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "fb9f7f54-ff98-428b-9fa9-b39c50210c3a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JWST Calibration Pipeline Version: 1.15.1\n",
+      "Using CRDS Context: jwst_1295.pmap\n"
+     ]
+    }
+   ],
    "source": [
     "# Basic system utilities for interacting with files\n",
     "# ----------------------General Imports------------------------------------\n",
@@ -267,18 +309,19 @@
     "# Numpy for doing calculations\n",
     "import numpy as np\n",
     "\n",
+    "# To display full ouptut of cell, not just the last result\n",
+    "from IPython.core.interactiveshell import InteractiveShell\n",
+    "InteractiveShell.ast_node_interactivity = \"all\"\n",
+    "\n",
     "# --------------------Astroquery Imports------------------------------\n",
     "# ASCII files, and downloading demo files\n",
     "from astroquery.mast import Observations\n",
     "\n",
     "# ----------------Matplotlib for visualizing images-------------------\n",
-    "#from jdaviz import Imviz\n",
-    "#import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "# -------------------Astropy routines for visualizing detected sources----------\n",
     "from astropy.table import Table\n",
-    "#from astropy.coordinates import SkyCoord\n",
     "\n",
     "# ----------------------JWST calibration pipeline------------------------\n",
     "import jwst\n",
@@ -327,7 +370,7 @@
     "[F770W filter](https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument/miri-observing-modes/miri-imaging#MIRIImaging-MIRIFiltersImagingfilters)\n",
     "and start with uncalibrated data products. The files are named\n",
     "`jw01040001005_03103_0000n_miri_uncal.fits`, where *n* refers to the\n",
-    " dither step number which ranges from 1 - 5.\n",
+    "dither step number which ranges from 1 - 5.\n",
     "\n",
     "More information about the JWST file naming conventions can be found at:\n",
     "https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/file_naming.html"
@@ -335,10 +378,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "8d595f1e-2590-4f01-bb92-13bb43a22b3c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running in demonstration mode and will download example data from MAST!\n"
+     ]
+    }
+   ],
    "source": [
     "# Set up the program information and paths for demo program\n",
     "if demo_mode:\n",
@@ -354,7 +405,7 @@
     "    # Ensure filepaths for input data exist\n",
     "    if not os.path.exists(uncal_dir):\n",
     "        os.makedirs(uncal_dir)\n",
-    "        \n",
+    "\n",
     "    # Create directory if it does not exist\n",
     "    if not os.path.isdir(data_dir):\n",
     "        os.mkdir(data_dir)"
@@ -404,7 +455,6 @@
     "\n",
     "    # Science files\n",
     "    sci_files_to_download = []\n",
-    "    #sci_files_to_download = [match for match in sci_files_to_download if ('jw' + program + sci_observtn + visit) in match]\n",
     "\n",
     "    # Loop over visits identifying uncalibrated files that are associated\n",
     "    # with them\n",
@@ -418,7 +468,6 @@
     "\n",
     "    # Download only the files in a single visit\n",
     "    sci_files_to_download = [match for match in sci_files_to_download if ('jw' + program + sci_observtn + visit) in match]\n",
-    "\n",
     "    sci_files_to_download = sorted(sci_files_to_download)\n",
     "    print(f\"Science files selected for downloading: {len(sci_files_to_download)}\")"
    ]
@@ -429,7 +478,7 @@
    "metadata": {},
    "source": [
     "Download all the uncal files and place them into the appropriate\n",
-    "directories.\n",
+    "directories.<br>\n",
     "\n",
     "<div class=\"alert alert-block alert-warning\">\n",
     "Warning: If this notebook is halted during this step the downloaded file\n",
@@ -462,7 +511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "bffbedc3-fbe3-4c56-ad18-85b5d0c7d880",
    "metadata": {},
    "outputs": [],
@@ -494,10 +543,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "f767a7fa-50cb-4411-8aef-a32b7fde8917",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "./mir_im_demo_data/Obs001/uncal/jw01040001005_03103_00001_mirimage_uncal.fits\n",
+      "Instrument: MIRI\n",
+      "Filter: F770W\n",
+      "Number of integrations: 1\n",
+      "Number of groups: 6\n",
+      "Readout pattern: FASTR1\n",
+      "Dither position number: 1\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "uncal_files = sorted(glob.glob(os.path.join(uncal_dir, '*_uncal.fits')))\n",
     "\n",
@@ -524,11 +589,11 @@
    "source": [
     "From the above, we confirm that the data file is for the MIRI instrument\n",
     "using the `F770W` filter in the [Filter Wheel](https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument/miri-instrumentation/miri-filters-and-dispersers#gsc.tab=0). This observation uses\n",
-    "the [`MIR` readout pattern](https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument/miri-instrumentation/miri-detector-overview/miri-detector-readout-overview#gsc.tab=0) FASTR1,\n",
+    "the MIRI [readout pattern](https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument/miri-instrumentation/miri-detector-overview/miri-detector-readout-overview#gsc.tab=0) FASTR1,\n",
     "6 groups per integration, and 1 integration per exposure. This data file\n",
     "is the 1st dither position in this exposure sequence. For more information\n",
     "about how JWST exposures are defined by up-the-ramp sampling, see the\n",
-    "[Understanding Exposure Times JDox article](https://jwst-docs.stsci.edu/understanding-exposure-times).\n",
+    "[Understanding Exposure Times JDox article](https://jwst-docs.stsci.edu/understanding-exposure-times).<br>\n",
     "\n",
     "This metadata will be the same for all exposures in this observation other\n",
     "than the dither position number."
@@ -559,34 +624,35 @@
     "These `*_rate.fits` products are 2D (nrows x ncols), averaged over all\n",
     "integrations. 3D countrate data products (`*_rateints.fits`) are also\n",
     "created (nintegrations x nrows x ncols) which have the fitted ramp slopes\n",
-    "for each integration.\n",
+    "for each integration.<br>\n",
     "\n",
-    "By default, all steps in the Detector1 stage of the pipeline are run for\n",
-    "MIRI except: the `group_scale`, `ipc` and the `gain_scale` steps. \n",
+    "By default, all steps in the `Detector1` stage of the pipeline are run for\n",
+    "MIRI except: the `group_scale`, `ipc` and the `gain_scale` steps.<br>\n",
     "\n",
     "MIRI performs a few pipeline steps in calwebb_detector1 that are not performed for other instruments.\n",
-    "The [`emicorr`](https://jwst-pipeline.readthedocs.io/en/latest/jwst/emicorr/index.html#emicorr-step) step corrects\n",
-    "for known noise patterns in MIRI data. For certain subarrays, these noise patterns are clearly imprinted on \n",
-    "the data in the `rate.fits` files.\n",
+    "The [emicorr](https://jwst-pipeline.readthedocs.io/en/latest/jwst/emicorr/index.html#emicorr-step) step corrects\n",
+    "for known noise patterns in MIRI data. For certain subarrays, these noise patterns are clearly imprinted on\n",
+    "the data in the `rate.fits` files.<br>\n",
     "\n",
-    "The [`firstframe`](https://jwst-pipeline.readthedocs.io/en/latest/jwst/firstframe/index.html#firstframe-step) step\n",
-    "flags the first frame in each integration as bad, if the number of groups per integration is greater than 3. \n",
+    "The [firstframe](https://jwst-pipeline.readthedocs.io/en/latest/jwst/firstframe/index.html#firstframe-step) step\n",
+    "flags the first frame in each integration as bad, if the number of groups per integration is greater than 3.<br>\n",
     "\n",
-    "The [`lastframe`](https://jwst-pipeline.readthedocs.io/en/latest/jwst/lastframe/index.html#lastframe-step) step\n",
-    "flags the last frame in each integration as bad, if the number of groups per integration is greater than 2.\n",
+    "The [lastframe](https://jwst-pipeline.readthedocs.io/en/latest/jwst/lastframe/index.html#lastframe-step) step\n",
+    "flags the last frame in each integration as bad, if the number of groups per integration is greater than 2.<br>\n",
     "\n",
-    "The [`reset`](https://jwst-pipeline.readthedocs.io/en/latest/jwst/reset/index.html#reset-step) correction step\n",
-    "corrects for the reset anomaly effect. This effect is caused by the non-ideal behavior of the field effect transistor (FET) upon resetting \n",
-    "in the dark causing the initial frames in an integration to be offset from their expected values\n",
+    "The [reset](https://jwst-pipeline.readthedocs.io/en/latest/jwst/reset/index.html#reset-step) correction step\n",
+    "corrects for the reset anomaly effect. This effect is caused by the non-ideal behavior of the field effect\n",
+    "transistor (FET) upon resetting in the dark causing the initial frames in an integration to be offset\n",
+    "from their expected values.<br>\n",
     "\n",
-    "The [`rscd`](https://jwst-pipeline.readthedocs.io/en/latest/jwst/rscd/index.html#rscd-step) step reads a reference \n",
-    "file for each data file and determines how many frames at the start of a ramp should be flagged as bad. There are a \n",
-    "number of nonlinearities at the start of MIRI ramps, and the flagging allows the more linear portion of the ramp to \n",
+    "The [rscd](https://jwst-pipeline.readthedocs.io/en/latest/jwst/rscd/index.html#rscd-step) step reads a reference\n",
+    "file for each data file and determines how many frames at the start of a ramp should be flagged as bad. There are a\n",
+    "number of nonlinearities at the start of MIRI ramps, and the flagging allows the more linear portion of the ramp to\n",
     "be used for jump detection and ramp fitting, without using the initial, non-linear portion of the ramp. The number\n",
-    "of groups flagged depend on filter and subarray.\n",
+    "of groups flagged depend on filter and subarray.<br>\n",
     "\n",
     "As of CRDS context `jwst_1201.pmap` and later, the\n",
-    "[`jump` step](https://jwst-pipeline.readthedocs.io/en/latest/api/jwst.jump.JumpStep.html)\n",
+    "[jump](https://jwst-pipeline.readthedocs.io/en/latest/api/jwst.jump.JumpStep.html) step\n",
     "of the `DETECTOR1` stage of the pipeline will remove residuals associated\n",
     "with [showers](https://jwst-docs.stsci.edu/known-issues-with-jwst-data/shower-and-snowball-artifacts)\n",
     "for the MIRI imaging mode, but only for data with filter F1500W and shorter. The default parameters for this correction,\n",
@@ -608,11 +674,11 @@
     "\n",
     "# Boilerplate dictionary setup\n",
     "det1dict = {}\n",
-    "det1dict['group_scale'], det1dict['dq_init'], det1dict['emicorr'], det1dict['saturation'] = {}, {}, {}, {}\n",
-    "det1dict['firstframe'], det1dict['lastframe'], det1dict['reset'] = {}, {}, {}\n",
-    "det1dict['linearity'], det1dict['rscd'], det1dict['dark_current'], = {}, {}, {}\n",
-    "det1dict['refpix'], det1dict['jump'], det1dict['ramp_fit'] = {}, {}, {}\n",
-    "det1dict['gain_scale'] = {}\n",
+    "det1dict['group_scale'], det1dict['dq_init'], det1dict['emicorr'] = {}, {}, {}\n",
+    "det1dict['saturation'], det1dict['firstframe'], det1dict['lastframe'] = {}, {}, {}\n",
+    "det1dict['reset'], det1dict['linearity'], det1dict['rscd'] = {}, {}, {}\n",
+    "det1dict['dark_current'], det1dict['refpix'], det1dict['jump'] = {}, {}, {}\n",
+    "det1dict['ramp_fit'], det1dict['gain_scale'] = {}, {}\n",
     "\n",
     "# Overrides for whether or not certain steps should be skipped\n",
     "# skipping the refpix step\n",
@@ -621,23 +687,23 @@
     "\n",
     "# Overrides for various reference files\n",
     "# Files should be in the base local directory or provide full path\n",
-    "#det1dict['dq_init']['override_mask'] = 'myfile.fits' # Bad pixel mask\n",
-    "#det1dict['saturation']['override_saturation'] = 'myfile.fits' # Saturation\n",
-    "#det1dict['reset']['override_reset'] = 'myfile.fits' # Reset\n",
-    "#det1dict['linearity']['override_linearity'] = 'myfile.fits' # Linearity\n",
-    "#det1dict['rscd']['override_rscd'] = 'myfile.fits' # RSCD\n",
-    "#det1dict['dark_current']['override_dark'] = 'myfile.fits' # Dark current subtraction\n",
-    "#det1dict['jump']['override_gain'] = 'myfile.fits' # Gain used by jump step\n",
-    "#det1dict['ramp_fit']['override_gain'] = 'myfile.fits' # Gain used by ramp fitting step\n",
-    "#det1dict['jump']['override_readnoise'] = 'myfile.fits' # Read noise used by jump step\n",
-    "#det1dict['ramp_fit']['override_readnoise'] = 'myfile.fits' # Read noise used by ramp fitting step\n",
+    "#det1dict['dq_init']['override_mask'] = 'myfile.fits'  # Bad pixel mask\n",
+    "#det1dict['saturation']['override_saturation'] = 'myfile.fits'  # Saturation\n",
+    "#det1dict['reset']['override_reset'] = 'myfile.fits'  # Reset\n",
+    "#det1dict['linearity']['override_linearity'] = 'myfile.fits'  # Linearity\n",
+    "#det1dict['rscd']['override_rscd'] = 'myfile.fits'  # RSCD\n",
+    "#det1dict['dark_current']['override_dark'] = 'myfile.fits'  # Dark current subtraction\n",
+    "#det1dict['jump']['override_gain'] = 'myfile.fits'  # Gain used by jump step\n",
+    "#det1dict['ramp_fit']['override_gain'] = 'myfile.fits'  # Gain used by ramp fitting step\n",
+    "#det1dict['jump']['override_readnoise'] = 'myfile.fits'  # Read noise used by jump step\n",
+    "#det1dict['ramp_fit']['override_readnoise'] = 'myfile.fits'  # Read noise used by ramp fitting step\n",
     "\n",
     "# Turn on multi-core processing (off by default).  Choose what fraction of cores to use (quarter, half, or all)\n",
     "det1dict['jump']['maximum_cores'] = 'half'\n",
     "\n",
     "# Alter parameters to optimize removal of shower residuals (example)\n",
-    "#det1dict['jump']['after_jump_flag_dn1'] = X  #A floating point value in units of DN\n",
-    "#det1dict['jump']['after_jump_flag_time1'] = x.x  #A floating point value in units of seconds"
+    "#det1dict['jump']['after_jump_flag_dn1'] = X  # A floating point value in units of DN\n",
+    "#det1dict['jump']['after_jump_flag_time1'] = x.x # A floating point value in units of seconds"
    ]
   },
   {
@@ -680,19 +746,64 @@
     "### Exploring the data\n",
     "\n",
     "Identify `*_rate.fits` files and verify which pipeline steps were run and\n",
-    "which calibration reference files were applied.\n",
+    "which calibration reference files were applied.<br>\n",
     "\n",
     "The header contains information about which calibration steps were\n",
     "completed and skipped and which reference files were used to process the\n",
-    "data."
+    "data.<br>"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "1c122766-a545-4042-93e8-f68c18f62fdf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'charge_migration': 'SKIPPED',\n",
+       " 'dark_sub': 'COMPLETE',\n",
+       " 'dq_init': 'COMPLETE',\n",
+       " 'emicorr': 'COMPLETE',\n",
+       " 'firstframe': 'COMPLETE',\n",
+       " 'gain_scale': 'SKIPPED',\n",
+       " 'group_scale': 'SKIPPED',\n",
+       " 'ipc': 'SKIPPED',\n",
+       " 'jump': 'COMPLETE',\n",
+       " 'lastframe': 'COMPLETE',\n",
+       " 'linearity': 'COMPLETE',\n",
+       " 'ramp_fit': 'COMPLETE',\n",
+       " 'refpix': 'SKIPPED',\n",
+       " 'reset': 'COMPLETE',\n",
+       " 'rscd': 'COMPLETE',\n",
+       " 'saturation': 'COMPLETE'}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'crds': {'context_used': 'jwst_1295.pmap', 'sw_version': '11.18.1'},\n",
+       " 'dark': {'name': 'crds://jwst_miri_dark_0103.fits'},\n",
+       " 'emicorr': {'name': 'crds://jwst_miri_emicorr_0002.asdf'},\n",
+       " 'gain': {'name': 'crds://jwst_miri_gain_0034.fits'},\n",
+       " 'linearity': {'name': 'crds://jwst_miri_linearity_0032.fits'},\n",
+       " 'mask': {'name': 'crds://jwst_miri_mask_0036.fits'},\n",
+       " 'readnoise': {'name': 'crds://jwst_miri_readnoise_0085.fits'},\n",
+       " 'reset': {'name': 'crds://jwst_miri_reset_0077.fits'},\n",
+       " 'rscd': {'name': 'crds://jwst_miri_rscd_0017.fits'},\n",
+       " 'saturation': {'name': 'crds://jwst_miri_saturation_0034.fits'}}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# find rate files\n",
     "rate_files = sorted(glob.glob(os.path.join(det1_dir, '*_rate.fits')))\n",
@@ -701,24 +812,9 @@
     "rate_f = datamodels.open(rate_files[0])\n",
     "\n",
     "# Check which steps were run\n",
-    "rate_f.meta.cal_step.instance"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2f2396cc-939f-44a6-878c-b33955796da8",
-   "metadata": {},
-   "source": [
-    "Check which reference files were used to calibrate the dataset:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c525e133-d875-4ea7-9552-d7f0df05747c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "rate_f.meta.cal_step.instance\n",
+    "\n",
+    "# Check which reference files were used to calibrate the dataset:\n",
     "rate_f.meta.ref_file.instance"
    ]
   },
@@ -729,22 +825,24 @@
    "source": [
     "## 6. Image2 Pipeline \n",
     "\n",
-    "In the [Image2 stage of the pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image2.html),\n",
+    "In the [Image2](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image2.html) stage of the pipeline,\n",
     "calibrated unrectified data products are created (`*_cal.fits` or\n",
     "`*_calints.fits` files, depending on whether the input files are\n",
     "`*_rate.fits` or `*_rateints.fits`). \n",
     "\n",
-    "In this pipeline processing stage, [background subtraction step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/background_step/index.html#background-step) is performed if the data have a dedicated background defined,\n",
+    "In this pipeline processing stage, the\n",
+    "[background subtraction](https://jwst-pipeline.readthedocs.io/en/latest/jwst/background_step/index.html#background-step)\n",
+    "step is performed if the data have a dedicated background defined,\n",
     "the [world coordinate system (WCS)](https://jwst-pipeline.readthedocs.io/en/latest/jwst/assign_wcs/index.html#assign-wcs-step)\n",
     "is assigned, the data are [flat fielded](https://jwst-pipeline.readthedocs.io/en/latest/jwst/flatfield/index.html#flatfield-step),\n",
     "and a [photometric calibration](https://jwst-pipeline.readthedocs.io/en/latest/jwst/photom/index.html#photom-step)\n",
     "is applied to convert from units of countrate (ADU/s) to surface brightness (MJy/sr).\n",
     "\n",
-    "The [resampling step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step)\n",
-    "is performed, to create resampled images of each dither position, but this is only a quick-look product. The\n",
-    "resampling step occurs during the `Image3` stage by default. While the\n",
-    "resampling step is done in the `Image2` stage, the data quality from the\n",
-    "`Image3` stage will be better since the bad pixels, which adversely affect\n",
+    "The [resampling](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step)\n",
+    "step is performed, to create resampled images of each dither position, but this is\n",
+    "only a quick-look product. The resampling step occurs during the `Image3` stage by\n",
+    "default. While the resampling step is done in the `Image2` stage, the data quality\n",
+    "from the `Image3` stage will be better since the bad pixels, which adversely affect\n",
     "both the centroids and photometry in individual images, will be mostly\n",
     "removed."
    ]
@@ -801,11 +899,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Find all rate.fits files\n",
     "sstring = os.path.join(det1_dir, 'jw*rate.fits')  # Use files from the detector1 output folder\n",
     "rate_files = sorted(glob.glob(sstring))\n",
+    "\n",
     "for ii in range(0, len(rate_files)):\n",
     "    rate_files[ii] = os.path.abspath(rate_files[ii])\n",
     "rate_files = np.array(rate_files)\n",
+    "\n",
     "print(f\"Found  {str(len(rate_files))} science files\")"
    ]
   },
@@ -818,9 +919,8 @@
    },
    "outputs": [],
    "source": [
-    "# Run Image2 stage of pipeline, specifying:\n",
-    "# output directory to save *_cal.fits files\n",
-    "# save_results flag set to True so the rate files are saved\n",
+    "# Run Image2 stage of pipeline, specifying the output directory to save *_cal.fits files\n",
+    "# and save_results flag set to True so the rate files are saved\n",
     "\n",
     "if doimage2:\n",
     "    for rate in rate_files:\n",
@@ -847,7 +947,7 @@
    "id": "da57b7d0-95ef-4227-b730-6f54a3eaaa16",
    "metadata": {},
    "source": [
-    "### Verify which pipeline steps were run"
+    "### Verify which pipeline steps were run and reference files used"
    ]
   },
   {
@@ -863,24 +963,9 @@
     "cal_f = datamodels.open(cal_files[0])\n",
     "\n",
     "# Check which steps were run:\n",
-    "cal_f.meta.cal_step.instance"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b77293ab-4eaa-4ebd-9f9b-bef8f6a2300f",
-   "metadata": {},
-   "source": [
-    "Check which reference files were used to calibrate the dataset:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6544744b-804e-4583-8311-e47b5e16c7fb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "cal_f.meta.cal_step.instance\n",
+    "\n",
+    "# Check which reference files were used to calibrate the dataset:\n",
     "cal_f.meta.ref_file.instance"
    ]
   },
@@ -891,21 +976,35 @@
    "source": [
     "## 7. Image3 Pipeline\n",
     "\n",
-    "In the [Image3 stage of the pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image3.html),\n",
-    "the individual `*_cal.fits` files for each of the dither positions are combined to one single\n",
-    "distortion corrected image. First, an [Association](https://jwst-pipeline.readthedocs.io/en/latest/jwst/associations/overview.html)\n",
+    "In the [Image3](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_image3.html)\n",
+    "stage of the pipeline, the individual `*_cal.fits` files for each of the dither positions are\n",
+    "combined to one single distortion corrected image. First, an \n",
+    "[Association](https://jwst-pipeline.readthedocs.io/en/latest/jwst/associations/overview.html)\n",
     "needs to be created to inform the pipeline that these individual exposures are linked together.\n",
     "\n",
     "By default, the `Image3` stage of the pipeline performs the following steps on MIRI data:\n",
     "* [tweakreg](https://jwst-pipeline.readthedocs.io/en/latest/jwst/tweakreg/index.html#tweakreg-step) -\n",
-    "  creates source catalogs of pointlike sources for each input image. The source catalog for each input image is compared to each other to derive coordinate transforms to align the images relative to each other.\n",
-    "* As of pipeline version 1.14.0, the default source finding algorithm is `IRAFStarFinder`.\n",
-    "* [skymatch](https://jwst-pipeline.readthedocs.io/en/latest/jwst/skymatch/index.html#skymatch-step) - measures the background level from the sky to use as input into the subsequent `outlier detection` and `resample` steps.\n",
-    "* [outlier detection](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/index.html#outlier-detection-step) - flags any remaining cosmic rays, bad pixels, or other artifacts not already flagged during the `DETECTOR1` stage of the pipeline, using all input images to create a median image so that outliers in individual images can be identified.\n",
-    "* [resample](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step) - resamples each input image based on its WCS and distortion information and creates a single undistorted image.\n",
-    "* [source catalog](https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/index.html#source-catalog-step) - creates a catalog of detected sources along with measured photometries and morphologies (i.e., point-like vs extended). Useful for quicklooks, but optimization is likely needed for specific science cases. Users may wish to experiment with changing the `snr_threshold` and `deblend` options. Modifications to the following parameters will not significantly improve data quality and it is advised to keep them at their default values: `aperture_ee1`, `aperture_ee2`, `aperture_ee3`, `ci1_star_threshold`, `ci2_star_threshold`.\n",
+    "  creates source catalogs of pointlike sources for each input image. The source catalog for each input\n",
+    "  image is compared to each other to derive coordinate transforms to align the images relative to each other.\n",
+    "    * As of pipeline version 1.14.0, the default source finding algorithm is `IRAFStarFinder`.\n",
+    "* [skymatch](https://jwst-pipeline.readthedocs.io/en/latest/jwst/skymatch/index.html#skymatch-step) -\n",
+    "  measures the background level from the sky to use as input into the subsequent `outlier detection` and `resample` steps.\n",
+    "* [outlier detection](https://jwst-pipeline.readthedocs.io/en/latest/jwst/outlier_detection/index.html#outlier-detection-step) -\n",
+    "  flags any remaining cosmic rays, bad pixels, or other artifacts not already flagged during the `DETECTOR1` stage\n",
+    "  of the pipeline, using all input images to create a median image so that outliers in individual images can be identified.\n",
+    "* [resample](https://jwst-pipeline.readthedocs.io/en/latest/jwst/resample/index.html#resample-step) -\n",
+    "  resamples each input image based on its WCS and distortion information and creates a single undistorted image.\n",
+    "* [source catalog](https://jwst-pipeline.readthedocs.io/en/latest/jwst/source_catalog/index.html#source-catalog-step) -\n",
+    "  creates a catalog of detected sources along with measured photometries and morphologies (i.e., point-like vs extended).\n",
+    "  Useful for quicklooks, but optimization is likely needed for specific science cases. Users may wish to experiment with\n",
+    "  changing the `snr_threshold` and `deblend` options. Modifications to the following parameters will not significantly\n",
+    "  improve data quality and it is advised to keep them at their default values: `aperture_ee1`, `aperture_ee2`,\n",
+    "  `aperture_ee3`, `ci1_star_threshold`, `ci2_star_threshold`.\n",
     "\n",
-    "Some parameters that have been shown to give good results for miri data are to set the outlier_detection `scale` to '1.0 0.8', which is specified in the current parameter reference files, and to set the resample parameter `weight_type` to 'exptime', which is also currently set in the parameter reference file."
+    "Some values that have been shown to give good results for MIRI data are to set the outlier_detection's parameter `scale`\n",
+    "to '1.0 0.8' and to set the resample parameter `weight_type` to 'exptime', both currently set in the \n",
+    "[parameter reference file](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/parameter_files.html#parameter-files)\n",
+    "<I>pars-outlierdetectionstep</I>, but can be overridden as indicated below."
    ]
   },
   {
@@ -959,7 +1058,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Science Files need the cal.fits files\n",
+    "# Science Files need are the cal.fits files\n",
     "sstring = os.path.join(image2_dir, 'jw*cal.fits')\n",
     "cal_files = sorted(glob.glob(sstring))\n",
     "for ii in range(0, len(cal_files)):\n",
@@ -976,7 +1075,7 @@
    "source": [
     "### Create Association File\n",
     "\n",
-    "An association file lists the exposures to calibrated together in `Stage 3`\n",
+    "An association file lists the exposures to calibrated together in `Stage3`\n",
     "of the pipeline. Note that an association file is available for download\n",
     "from MAST, with a filename of `*_asn.json`. Here we show how to create an\n",
     "association file to point to the data products created when processing data\n",
@@ -1000,10 +1099,10 @@
     "    associations = asn_from_list.asn_from_list(cal_files,\n",
     "                                               rule=DMS_Level3_Base,\n",
     "                                               product_name='image3_association')\n",
-    "    \n",
+    "\n",
     "    associations.data['asn_type'] = 'image3'\n",
     "    associations.data['program'] = program\n",
-    "    \n",
+    "\n",
     "    # Format association as .json file\n",
     "    asn_filename, serialized = associations.dump(format=\"json\")\n",
     "\n",
@@ -1020,9 +1119,9 @@
    "source": [
     "### Run Image3 stage of the pipeline\n",
     "\n",
-    "Given the grouped exposures in the association file, the\n",
-    "`Image3` stage of the pipeline will produce:\n",
-    "* a `*_cr.fits` file produced by the `outlier_detection` step, where the `DQ` array marks the pixels flagged as outliers.\n",
+    "Given the grouped exposures in the association file, the products if the\n",
+    "`Image3` stage of the pipeline are:\n",
+    "* a `*_crf.fits` file produced by the `outlier_detection` step, where the `DQ` array marks the pixels flagged as outliers.\n",
     "* a final combined, rectified image with name `*_i2d.fits`,\n",
     "* a source catalog with name `*_cat.ecsv`,\n",
     "* a segmentation map file (`*_segm.fits`) which has integer values at the pixel locations where a source is detected where the pixel values match the source ID number in the catalog."
@@ -1062,39 +1161,97 @@
    "id": "4bcb6c40-fbb8-4226-b620-64b0c02c8ceb",
    "metadata": {},
    "source": [
-    "### Verify which pipeline steps were run"
+    "### Verify which pipeline steps were run and reference files used"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "c754530a-d4e2-493b-bf8b-bf8d1ad08770",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'assign_wcs': 'COMPLETE',\n",
+       " 'charge_migration': 'SKIPPED',\n",
+       " 'dark_sub': 'COMPLETE',\n",
+       " 'dq_init': 'COMPLETE',\n",
+       " 'emicorr': 'COMPLETE',\n",
+       " 'firstframe': 'COMPLETE',\n",
+       " 'flat_field': 'COMPLETE',\n",
+       " 'gain_scale': 'SKIPPED',\n",
+       " 'group_scale': 'SKIPPED',\n",
+       " 'ipc': 'SKIPPED',\n",
+       " 'jump': 'COMPLETE',\n",
+       " 'lastframe': 'COMPLETE',\n",
+       " 'linearity': 'COMPLETE',\n",
+       " 'outlier_detection': 'COMPLETE',\n",
+       " 'photom': 'COMPLETE',\n",
+       " 'ramp_fit': 'COMPLETE',\n",
+       " 'refpix': 'SKIPPED',\n",
+       " 'resample': 'COMPLETE',\n",
+       " 'reset': 'COMPLETE',\n",
+       " 'rscd': 'COMPLETE',\n",
+       " 'saturation': 'COMPLETE',\n",
+       " 'skymatch': 'COMPLETE',\n",
+       " 'tweakreg': 'COMPLETE'}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'area': {'name': 'crds://jwst_miri_area_0006.fits'},\n",
+       " 'camera': {'name': 'N/A'},\n",
+       " 'collimator': {'name': 'N/A'},\n",
+       " 'crds': {'context_used': 'jwst_1295.pmap', 'sw_version': '11.18.1'},\n",
+       " 'dark': {'name': 'crds://jwst_miri_dark_0103.fits'},\n",
+       " 'dflat': {'name': 'N/A'},\n",
+       " 'disperser': {'name': 'N/A'},\n",
+       " 'distortion': {'name': 'crds://jwst_miri_distortion_0047.asdf'},\n",
+       " 'emicorr': {'name': 'crds://jwst_miri_emicorr_0002.asdf'},\n",
+       " 'fflat': {'name': 'N/A'},\n",
+       " 'filteroffset': {'name': 'crds://jwst_miri_filteroffset_0008.asdf'},\n",
+       " 'flat': {'name': 'crds://jwst_miri_flat_0785.fits'},\n",
+       " 'fore': {'name': 'N/A'},\n",
+       " 'fpa': {'name': 'N/A'},\n",
+       " 'gain': {'name': 'crds://jwst_miri_gain_0034.fits'},\n",
+       " 'ifufore': {'name': 'N/A'},\n",
+       " 'ifupost': {'name': 'N/A'},\n",
+       " 'ifuslicer': {'name': 'N/A'},\n",
+       " 'linearity': {'name': 'crds://jwst_miri_linearity_0032.fits'},\n",
+       " 'mask': {'name': 'crds://jwst_miri_mask_0036.fits'},\n",
+       " 'msa': {'name': 'N/A'},\n",
+       " 'ote': {'name': 'N/A'},\n",
+       " 'photom': {'name': 'crds://jwst_miri_photom_0218.fits'},\n",
+       " 'readnoise': {'name': 'crds://jwst_miri_readnoise_0085.fits'},\n",
+       " 'regions': {'name': 'N/A'},\n",
+       " 'reset': {'name': 'crds://jwst_miri_reset_0077.fits'},\n",
+       " 'rscd': {'name': 'crds://jwst_miri_rscd_0017.fits'},\n",
+       " 'saturation': {'name': 'crds://jwst_miri_saturation_0034.fits'},\n",
+       " 'sflat': {'name': 'N/A'},\n",
+       " 'specwcs': {'name': 'N/A'},\n",
+       " 'wavelengthrange': {'name': 'N/A'}}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Identify *_i2d file and open as datamodel\n",
     "i2d = glob.glob(os.path.join(image3_dir, \"*_i2d.fits\"))[0]\n",
     "i2d_f = datamodels.open(i2d)\n",
     "\n",
     "# Check which steps were run\n",
-    "i2d_f.meta.cal_step.instance"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f73c5280-69a5-4796-b78f-724078a94d2b",
-   "metadata": {},
-   "source": [
-    "Check which reference files were used to calibrate the dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0cfb0842-cc95-42d5-8852-593b85032c52",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "i2d_f.meta.cal_step.instance\n",
+    "\n",
+    "# Check which reference files were used to calibrate the dataset\n",
     "i2d_f.meta.ref_file.instance"
    ]
   },
@@ -1130,8 +1287,8 @@
     "sstring = os.path.join(image3_dir, '*i2d.fits')\n",
     "miri_mosaic_file = glob.glob(sstring)\n",
     "print(miri_mosaic_file)\n",
+    "\n",
     "# Read your mosaic image into an ImageModel datamodel\n",
-    "#miri_mosaic_file =  association_im3 + '_i2d.fits'\n",
     "miri_mosaic = ImageModel(miri_mosaic_file[0])\n",
     "\n",
     "plt.figure(figsize=(20, 20))\n",
@@ -1204,7 +1361,7 @@
    "source": [
     "### Mark the extended and point sources on the image\n",
     "\n",
-    "Display combined image with point sources marked with red dots and extended sources marked with blue triangles. You will see that there are a grouping of sources near the top edge of the MIRI image, several of which may be spurious sources, which tend to be found near image edges.\n"
+    "Display combined image with point sources marked with red dots and extended sources marked with blue triangles. You will see that there are a grouping of sources near the top edge of the MIRI image, several of which may be spurious sources, which tend to be found near image edges."
    ]
   },
   {
@@ -1215,32 +1372,23 @@
    "outputs": [],
    "source": [
     "# Look at mosaic data and sources found with source_catalog\n",
-    "\n",
     "fig, ax = plt.subplots(figsize=(20, 20))\n",
     "\n",
     "# Set up image\n",
     "cax = ax.imshow(miri_mosaic.data, cmap='Greys', origin='lower', vmin=display_vals[0], vmax=display_vals[1])\n",
-    "ax.scatter(miri_x, miri_y, lw=1, s=10, color='red') # overplot point source positions\n",
-    "ax.scatter(ext_x, ext_y, lw=1, s=20, color='blue', marker='v') # overplot extended source positions\n",
+    "ax.scatter(miri_x, miri_y, lw=1, s=10, color='red')  # overplot point source positions\n",
+    "ax.scatter(ext_x, ext_y, lw=1, s=20, color='blue', marker='v')  # overplot extended source positions\n",
     "\n",
     "# Set up colorbar\n",
     "cb = fig.colorbar(cax)\n",
     "cb.ax.set_ylabel('MJy/str', fontsize=14)\n",
     "\n",
-    "#Set labels \n",
+    "#Set labels\n",
     "ax.set_xlabel('X', fontsize=16)\n",
     "ax.set_ylabel('Y', fontsize=16)\n",
     "ax.set_title('Final MIRI mosaic', fontsize=16)\n",
     "plt.tight_layout()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8bad13f6-7b9c-438d-83e0-cb7751abf839",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1267,7 +1415,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/MIRI/requirements.txt
+++ b/notebooks/MIRI/requirements.txt
@@ -1,3 +1,3 @@
 numpy<2.0
-jwst==1.14.0
+jwst==1.15.1
 astroquery


### PR DESCRIPTION
MIRI  Imaging Technical Review

1. Changed requirements file to use jwst 1.15.1 before it was 1.14.0
2. Corrected typos and removed unnecessary extra lines.
3. Changed text about reference files because that is changing.
4. Fixed link to visualize data
5. Updated information about the CRDS context to use. This to indicate the new data-processing style
6. Added print for CRDS_CONTEXT
7. Added to import InteractiveShell to display all results in shell
8. Fixed format for links to steps in image2.
9. Fixed format for bulleted list (first bullet ) in Image3. Also added info about parameter reference file for outlier detection.
10. Condensed output for steps run and reference files used